### PR TITLE
support more custom deploy usages by not requiring a deploy:restart

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,7 @@
+== 2.0.0 (October 2018)
+
+*   Execute before cleanup to support custom deploy tasks
+
 == 1.0.0 (May 2017)
 
 * Forked and upgraded to capistrano v3

--- a/lib/capistrano/tagging3/version.rb
+++ b/lib/capistrano/tagging3/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   class Tagging3
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/lib/capistrano/tasks/tagging3.rake
+++ b/lib/capistrano/tasks/tagging3.rake
@@ -1,6 +1,6 @@
 namespace :tagging3 do
   set :tagging3_format, ':rails_env_:release'
-  
+
   def fetch_or_send(method)
     fetch method, respond_to?(method) ? send(method) : nil
   end
@@ -56,6 +56,6 @@ namespace :tagging3 do
   end
 end
 
-after  'deploy:restart', 'tagging3:deploy'
+before  'tagging3:cleanup', 'tagging3:deploy'
 before 'deploy:cleanup', 'tagging3:cleanup'
 


### PR DESCRIPTION
What are your thoughts on this? If using a more complicated server restart set-up (like using passenger with apache, and you need to write a custom server restart hook) you can't rely on deploy:restart, as it won't execute and thus the tag won't ever be created.